### PR TITLE
Add Flask-based Linebot skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+blood_pressure.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# blood_pressure_bot
-blood_pressure_bot
+# Blood Pressure Line Bot
+
+A simple Line Bot built with Flask to record blood pressure, send daily reminders and export trend charts.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the following environment variables:
+
+- `LINE_CHANNEL_SECRET` – your channel secret.
+- `LINE_CHANNEL_ACCESS_TOKEN` – your channel access token.
+- `LINE_USER_ID` – user ID to push daily reminder messages.
+
+3. Run the application:
+
+```bash
+python app.py
+```
+
+The bot listens on port `5000`.
+
+## Features
+
+- Send a message like `120/80` to record a blood pressure reading.
+- Daily reminder at 09:00 to input your reading.
+- Access `/export` to download data as CSV.
+- Access `/trend` to view a trend chart of your readings.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,104 @@
+import os
+from datetime import datetime
+from io import BytesIO
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from flask import Flask, request, send_file
+from linebot import LineBotApi, WebhookHandler
+from linebot.exceptions import InvalidSignatureError
+from linebot.models import MessageEvent, TextMessage, TextSendMessage
+import matplotlib.pyplot as plt
+
+from db import db_session, init_db, Record
+
+app = Flask(__name__)
+
+LINE_CHANNEL_SECRET = os.getenv("LINE_CHANNEL_SECRET", "YOUR_CHANNEL_SECRET")
+LINE_CHANNEL_ACCESS_TOKEN = os.getenv("LINE_CHANNEL_ACCESS_TOKEN", "YOUR_CHANNEL_ACCESS_TOKEN")
+
+line_bot_api = LineBotApi(LINE_CHANNEL_ACCESS_TOKEN)
+handler = WebhookHandler(LINE_CHANNEL_SECRET)
+
+scheduler = BackgroundScheduler()
+
+
+def send_daily_reminder():
+    """Send a daily reminder message."""
+    user_id = os.getenv("LINE_USER_ID")
+    if user_id:
+        line_bot_api.push_message(user_id, TextSendMessage(text="記得回報今天的血壓喔！"))
+
+
+scheduler.add_job(send_daily_reminder, 'cron', hour=9, minute=0)
+scheduler.start()
+
+
+@app.route("/callback", methods=['POST'])
+def callback():
+    signature = request.headers['X-Line-Signature']
+    body = request.get_data(as_text=True)
+    try:
+        handler.handle(body, signature)
+    except InvalidSignatureError:
+        return 'Invalid signature', 400
+    return 'OK'
+
+
+@handler.add(MessageEvent, message=TextMessage)
+def handle_message(event):
+    text = event.message.text
+    if '/' in text:
+        try:
+            systolic, diastolic = map(int, text.split('/'))
+            record = Record(
+                timestamp=datetime.now(),
+                systolic=systolic,
+                diastolic=diastolic,
+            )
+            db_session.add(record)
+            db_session.commit()
+            reply = f"已記錄血壓：{systolic}/{diastolic}"
+        except ValueError:
+            reply = "請輸入正確的血壓格式，例如 120/80"
+    else:
+        reply = "請輸入血壓數值，例如 120/80"
+    line_bot_api.reply_message(event.reply_token, TextSendMessage(text=reply))
+
+
+@app.route('/export', methods=['GET'])
+def export_csv():
+    """Export records as CSV."""
+    output = "timestamp,systolic,diastolic\n"
+    for rec in db_session.query(Record).order_by(Record.timestamp):
+        output += f"{rec.timestamp},{rec.systolic},{rec.diastolic}\n"
+    return app.response_class(output, mimetype='text/csv')
+
+
+@app.route('/trend', methods=['GET'])
+def trend_image():
+    """Return blood pressure trend image."""
+    records = db_session.query(Record).order_by(Record.timestamp).all()
+    if not records:
+        return 'No data', 404
+    dates = [rec.timestamp for rec in records]
+    sys_vals = [rec.systolic for rec in records]
+    dia_vals = [rec.diastolic for rec in records]
+
+    plt.figure(figsize=(10, 4))
+    plt.plot(dates, sys_vals, label='Systolic')
+    plt.plot(dates, dia_vals, label='Diastolic')
+    plt.xlabel('Date')
+    plt.ylabel('Pressure')
+    plt.legend()
+    plt.tight_layout()
+
+    buf = BytesIO()
+    plt.savefig(buf, format='png')
+    buf.seek(0)
+    plt.close()
+    return send_file(buf, mimetype='image/png')
+
+
+if __name__ == '__main__':
+    init_db()
+    app.run(host='0.0.0.0', port=5000)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, DateTime
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+engine = create_engine('sqlite:///blood_pressure.db')
+
+db_session = scoped_session(sessionmaker(bind=engine))
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+
+class Record(Base):
+    __tablename__ = 'records'
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    systolic = Column(Integer)
+    diastolic = Column(Integer)
+
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+line-bot-sdk
+APScheduler
+SQLAlchemy
+matplotlib


### PR DESCRIPTION
## Summary
- implement basic Flask Linebot with daily reminder using APScheduler
- store data in SQLite via SQLAlchemy
- allow CSV export and trend chart using matplotlib
- document setup and usage
- add requirements and gitignore

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_686b429cae6c8323b0e652079d5c18a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a LINE messaging bot for recording blood pressure readings via message.
  * Added daily reminder messages at 09:00.
  * Enabled exporting all blood pressure records as a CSV file.
  * Provided a trend chart endpoint to visualize blood pressure history.

* **Documentation**
  * Rewrote and expanded the README with setup instructions, feature descriptions, and usage details.

* **Chores**
  * Added a .gitignore to exclude cache and database files from version control.
  * Included a requirements.txt file listing all necessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->